### PR TITLE
Bug: Linting skipped for React FC that returns null

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -138,6 +138,12 @@ ruleTester.run(pluginName, plugin.rules["no-dom-globals-in-react-cc-render"], {
           return <div style={{ width }} />;
         }
        }`,
+    `class Header extends React.Component {
+        render() {
+          const width = window.innerWidth;
+          return null;
+        }
+       }`,
   ].map((code) => ({
     code,
     errors: [{ message: /Use of DOM global .* render/ }],
@@ -162,11 +168,6 @@ ruleTester.run(pluginName, plugin.rules["no-dom-globals-in-react-fc"], {
       }, []);
       return <div />;
     }`,
-    // this passes but should fail
-    `function Header({url}) {
-      const href = url + window.location.hash;
-      return null
-    }`,
   ].map((code) => ({ code })),
   invalid: [
     `const Header = () => {
@@ -185,10 +186,17 @@ ruleTester.run(pluginName, plugin.rules["no-dom-globals-in-react-fc"], {
       document.title = "Otto";
       return <><div>Header</div></>;
     }`,
-    // this fails as expected
+    `const Header = function ({url}) {
+      const href = url + window.location.hash
+      return <>{href}</>;
+    }`,
     `function Header ({url}) {
       const href = url + window.location.hash
       return <>{href}</>;
+    }`,
+    `function Header({url}) {
+      const href = url + window.location.hash;
+      return null
     }`,
   ].map((code) => ({
     code,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -162,6 +162,11 @@ ruleTester.run(pluginName, plugin.rules["no-dom-globals-in-react-fc"], {
       }, []);
       return <div />;
     }`,
+    // this passes but should fail
+    `function Header({url}) {
+      const href = url + window.location.hash;
+      return null
+    }`,
   ].map((code) => ({ code })),
   invalid: [
     `const Header = () => {
@@ -179,6 +184,11 @@ ruleTester.run(pluginName, plugin.rules["no-dom-globals-in-react-fc"], {
     `const Header = () => {
       document.title = "Otto";
       return <><div>Header</div></>;
+    }`,
+    // this fails as expected
+    `function Header ({url}) {
+      const href = url + window.location.hash
+      return <>{href}</>;
     }`,
   ].map((code) => ({
     code,


### PR DESCRIPTION
I noticed that this plugin is not erroring when it encounters a global in a React Functional component that returns `null`

```js
// this passes but should fail
function Header({url}) {
  const href = url + window.location.hash;
  return null
}
```

The bug is due to the assumption that a react component must return JSX: it can also return `null`. As a result I had to expand the `isReactFunctionComponent` to look for functions that start with an uppercase letter and return either JSX or null. 

I based my solution somewhat on https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/util/Components.js#L469 although I didn't exhaustively cover all the cases covered there.

Note this also adds coverage for the case of a class's `render` returning null.